### PR TITLE
TextAreaの横幅を、ページサイズに合わせて表示させる

### DIFF
--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -29,7 +29,7 @@ const StyledTextarea = styled.textarea.attrs<TextAreaProps>(({ onChange }) => {
 })`
   font-size: 16px;
   border-radius: 5px;
-  width: 340px;
+  width: 100%;
   height: 68px;
   border: none;
   outline: none;

--- a/src/components/TextArea/index.tsx
+++ b/src/components/TextArea/index.tsx
@@ -27,6 +27,7 @@ const StyledLabel = styled.label`
 const StyledTextarea = styled.textarea.attrs<TextAreaProps>(({ onChange }) => {
   onChange
 })`
+  display: block;
   font-size: 16px;
   border-radius: 5px;
   width: 100%;


### PR DESCRIPTION
old: 横幅を340pxと指定していました
new: 横幅を100%とし、ページの幅に合わせて適切に大きさが変わるようにしました